### PR TITLE
END:BUILD: Automatic request responsible assigment

### DIFF
--- a/hiring_module/hiring_app/views/request_creation/cex_contract_request_view.py
+++ b/hiring_module/hiring_app/views/request_creation/cex_contract_request_view.py
@@ -15,11 +15,15 @@ class CEXContractRequestView(CreateView):
     template_name = 'request_creation/cex_request_form.html'
 
     def form_valid(self, form):
-        # Assign created_by and estimated_completion_date fields
+        # Assign created_by, estimated_completion_date and responsibles fields
         current_user = self.request.user
         estimated_completion_date = datetime.now() + timedelta(days=30)
+        leader = utilities.findLeaderToAssign()
+        manager = utilities.findManagerToAssign()
         form.instance.estimated_completion_date = estimated_completion_date
         form.instance.created_by = current_user
+        form.instance.leader_assigned_to = leader
+        form.instance.manager_assigned_to = manager
 
         cex_contract_request = form.save(commit=False)
         cex_contract_request.create_snapshot()

--- a/hiring_module/hiring_app/views/request_creation/monitoring_contract_request_view.py
+++ b/hiring_module/hiring_app/views/request_creation/monitoring_contract_request_view.py
@@ -12,11 +12,15 @@ class MonitoringContractRequestView(CreateView):
     success_url = reverse_lazy('hiring_app:monitoring') 
 
     def form_valid(self, form):
-         # Assign created_by and estimated_completion_date fields
+        # Assign created_by, estimated_completion_date and responsibles fields
         current_user = self.request.user
         estimated_completion_date = datetime.now() + timedelta(days=15)
+        leader = utilities.findLeaderToAssign()
+        manager = utilities.findManagerToAssign()
         form.instance.estimated_completion_date = estimated_completion_date
         form.instance.created_by = current_user
+        form.instance.leader_assigned_to = leader
+        form.instance.manager_assigned_to = manager
         
         monitoring_contract_request = form.save(commit=False)
         monitoring_contract_request.create_snapshot()

--- a/hiring_module/hiring_app/views/request_creation/utilities.py
+++ b/hiring_module/hiring_app/views/request_creation/utilities.py
@@ -1,5 +1,9 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
+from hiring_app.model import CustomUser
+from django.db.models import Count
+from django.db.models import Q
+from django.contrib.auth.models import Group
 
 class utilities:
     # Send email to user when request is created
@@ -15,3 +19,35 @@ class utilities:
 
             message.attach_alternative(content, 'text/html')
             message.send()
+
+    def findLeaderToAssign():
+        #Find the leader with the least ammount of active requests
+        group = Group.objects.get(name="leader")
+        leaders_with_least_contracts = CustomUser.objects.filter(groups=group).annotate(
+            num_contracts=Count('leader_monitoringcontractrequest_requests', filter=(
+                Q(leader_monitoringcontractrequest_requests__state='pending') |
+                Q(leader_monitoringcontractrequest_requests__state='review') |
+                Q(leader_monitoringcontractrequest_requests__state='incomplete')
+            )) + Count('leader_cexcontractrequest_requests', filter=(
+                Q(leader_cexcontractrequest_requests__state='pending') |
+                Q(leader_cexcontractrequest_requests__state='review') |
+                Q(leader_cexcontractrequest_requests__state='incomplete')
+            ))
+        ).order_by('-num_contracts', 'last_name')
+        return leaders_with_least_contracts.first()
+    
+    def findManagerToAssign():
+        #Find the manager with the least ammount of active requests
+        group = Group.objects.get(name="manager")
+        managers_with_least_contracts = CustomUser.objects.filter(groups=group).annotate(
+            num_contracts=Count('manager_monitoringcontractrequest_requests', filter=(
+                Q(manager_monitoringcontractrequest_requests__state='pending') |
+                Q(manager_monitoringcontractrequest_requests__state='review') |
+                Q(manager_monitoringcontractrequest_requests__state='incomplete')
+            )) + Count('manager_cexcontractrequest_requests', filter=(
+                Q(manager_cexcontractrequest_requests__state='pending') |
+                Q(manager_cexcontractrequest_requests__state='review') |
+                Q(manager_cexcontractrequest_requests__state='incomplete')
+            ))
+        ).order_by('-num_contracts', 'last_name')
+        return managers_with_least_contracts.first()


### PR DESCRIPTION
What: Automatically assign a manager and a leader to a contract request, the user responsible is determined by comparing the ammount of active request the leaders or managers have and the one who has the less ammount of them all get's assigned, in case there are multiple with the same ammount it gets ordered alphabetically by the last name
Why: So the admin doesn't have to always add the leader and manager
ToDo: Add the same functionality when the provision of services contract is added
How: When creating a monitoring or cex request the leader and manager get assigned automatically