### PR TITLE
User list center container now displays real ammount of users

### DIFF
--- a/hiring_module/hiring_app/templates/admin_user/components/user_list_center_container.html
+++ b/hiring_module/hiring_app/templates/admin_user/components/user_list_center_container.html
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-    {% include 'admin_user/components/user_element_container.html' with count=1 status='Administradores' %}
-    {% include 'admin_user/components/user_element_container.html' with count=2 status='Lideres' %}
-    {% include 'admin_user/components/user_element_container.html' with count=2 status='Gestores' %}
+    {% include 'admin_user/components/user_element_container.html' with count=admins_ammount status='Administradores' %}
+    {% include 'admin_user/components/user_element_container.html' with count=leaders_ammount status='Lideres' %}
+    {% include 'admin_user/components/user_element_container.html' with count=managers_ammount status='Gestores' %}
 </div>

--- a/hiring_module/hiring_app/views/control_board/administrator_user_list_view.py
+++ b/hiring_module/hiring_app/views/control_board/administrator_user_list_view.py
@@ -21,11 +21,23 @@ class AdministratorUserListView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         users = CustomUser.objects.filter(groups__name__in=['admin', 'leader', 'manager'])
+        admins_ammount = 0
+        leaders_ammount = 0
+        managers_ammount = 0
         # Add a role field to each user object
         for user in users:
             user.role = str(user.groups.first())
+            if user.role == 'admin':
+                admins_ammount += 1
+            elif user.role == 'leader':
+                leaders_ammount += 1
+            elif user.role == 'manager':
+                managers_ammount += 1
         context['users'] = users
         context['actualgroup'] = 'admin'
+        context['admins_ammount'] = admins_ammount
+        context['leaders_ammount'] = leaders_ammount
+        context['managers_ammount'] = managers_ammount
         return context
     
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
What: Changed center container of user lists to display real ammount of admins, leaders and managers
Why: So the administrator can see exactly the ammount of users for each role
How to access: When logged in as and administrator click "Lista de usuarios" on the left side bar
ToDo: Nothing